### PR TITLE
Fixed cors and non-batch requests errors (#13)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,6 @@ indent_style = space
 indent_size = 2
 continuation_indent_size = 2
 trim_trailing_whitespace = true
+insert_final_newline = true
 end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,6 @@ indent_style = space
 indent_size = 2
 continuation_indent_size = 2
 trim_trailing_whitespace = true
-insert_final_newline = true
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Generates boiler-plate code for [golang graphql](https://github.com/neelance/gra
 * Resolver function is not generated for a GraphQL type which has a property with arguments. 
 It is assumed that such a property would require additional logic; so, it should be implemented manually. 
 Take a look at `sample/api/api-extra.go` for an example
-* A `server.gql.go` file is also generated which implements a custom http handler and runs a GraphQL server. 
+* A `server.gql.go` file is also generated which implements a custom http handler and runs a GraphQL server. It has dependency on graphql-go and cors libraries. 
 You can use this or your own http handler or built in one in [graphql-go](https://github.com/neelance/graphql-go)
 
 ## How to Use Generated Code
@@ -98,3 +98,4 @@ func main() {
 
 Hard fork of [graphql-gen-go](https://github.com/euforic/graphql-gen-go) and inspired by [protoc-gen-go](https://github.com/golang/protobuf/tree/master/protoc-gen-go).
 Thanks to [neelance](https://github.com/neelance) for the great [graphql-go](https://github.com/neelance/graphql-go) library. 
+Http custom handler is inspired by [graphql-go-example](https://github.com/tonyghita/graphql-go-example) 

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,3 +7,4 @@ import:
   version: ^0.0.1
 - package: github.com/spf13/viper
   version: ^1.0.0
+- package: github.com/rs/cors # this is required to run the sample-server

--- a/sample/api/server.gql.go
+++ b/sample/api/server.gql.go
@@ -9,6 +9,7 @@ import (
   "sync"
 
   "github.com/neelance/graphql-go"
+  "github.com/rs/cors"
 )
 
 const (
@@ -19,24 +20,39 @@ const (
 )
 
 type GqlServer struct {
-  Schema *graphql.Schema
-  Port   string
+  Schema      *graphql.Schema
+  Port        string
+  Request     gqlRequest
+  CorsOptions *cors.Options
   // TODO add facebook dataloader
 }
 
-func NewGqlServer(res GqlResolver, port string) *GqlServer {
+func NewGqlServer(res GqlResolver, port string, corsOptions *cors.Options) *GqlServer {
   return &GqlServer{
-    Schema: graphql.MustParseSchema(Schema, res),
-    Port:   port,
+    Schema:      graphql.MustParseSchema(Schema, res),
+    Port:        port,
+    CorsOptions: corsOptions,
   }
 }
 
 func (g *GqlServer) Serve() error {
+
   // TODO should we validate required fields of GqlServer
   addr := ":" + g.Port
   srv := &httpServer{g}
-  http.Handle("/graphql", srv)
-  return http.ListenAndServe(addr, nil)
+  mux := http.NewServeMux()
+
+  // configure pre-flight/cors request handler
+  var c *cors.Cors
+  if g.CorsOptions == nil {
+    c = cors.AllowAll()
+  } else {
+    c = cors.New(*g.CorsOptions)
+  }
+
+  mux.Handle("/graphql", srv)
+  handler := c.Handler(mux)
+  return http.ListenAndServe(addr, handler)
 }
 
 type httpServer struct {
@@ -67,6 +83,7 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
   // iterate over all parsed requests and use go routine to process them in parallel
   for i, q := range req.requests {
     go func(i int, q gqlRequest) {
+      h.Request = q
       res := h.Schema.Exec(r.Context(), q.Query, q.OpName, q.Variables)
       // FIXME expand returned errors to handle a resolver returning more than one error
       responses[i] = res
@@ -78,7 +95,17 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
   // TODO should we log errors?
 
-  resp, err := json.Marshal(responses)
+  var err error
+  var resp []byte
+  /**
+    * at this point there should be at least one response.
+    * in case of batch, we send a json array object otherwise a single json object
+   */
+  if req.batch {
+    resp, err = json.Marshal(responses)
+  } else {
+    resp, err = json.Marshal(responses[0])
+  }
   if err != nil {
     http.Error(w, "Server error", http.StatusInternalServerError)
     return

--- a/sample/test-server.go
+++ b/sample/test-server.go
@@ -163,7 +163,7 @@ func main() {
     people[3],
   }
 
-  gqlSrv := api.NewGqlServer(&resolver{}, Port)
+  gqlSrv := api.NewGqlServer(&resolver{}, Port, nil)
   err := gqlSrv.Serve()
   if err != nil {
     panic(err)


### PR DESCRIPTION
Closes #13 

## Test Notes

1. `make install build`
1. `make run-sample`
1. Send a preflight request to sample GraphQL server and verify it does not throw an error
1. Send a single GraphQL request to sample server and verify it returns a single json object

Sample Requests

```
1. Request 
curl -XOPTIONS localhost:7050/graphql -H "Content-Type: application/graphql" \ 
-H "Access-Control-Request-Method: POST" \
-d '{ person(id: "1000") { name email friends { name email } } }'

Expected Response
200 OK

2. Request
curl -XPOST localhost:7050/graphql -H "Content-Type: application/graphql" \
-d '{ person(id: "1000") { name email friends { name email } } }'

Expected Response
{
  "data": {
    "person": {
      "name": "Luke Skywalker",
      "email": "luke.skywalker@star.wars",
      "friends": [
        {
          "name": "Han Solo",
          "email": "han.solo@star.wars"
        },
        {
          "name": "Leia Organa",
          "email": "leia.organa@star.wars"
        }
      ]
    }
  }
}
```